### PR TITLE
Added buttons for map levels up/down navigation.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,6 +49,7 @@ gulp.task('js', function() {
 		'src/_js/leaflet.js',
 		'src/_js/leaflet.coordinates.js',
 		'src/_js/leaflet.crosshairs.js',
+		'src/_js/leaflet.levelbuttons.js',
 		require.resolve('leaflet-fullscreen'),
 		'src/_js/map.js'
 	])

--- a/src/_css/leaflet.levelbuttons.css
+++ b/src/_css/leaflet.levelbuttons.css
@@ -1,0 +1,3 @@
+.levelbuttons-panel {}
+
+.levelbuttons-panel-a {}

--- a/src/_js/leaflet.levelbuttons.js
+++ b/src/_js/leaflet.levelbuttons.js
@@ -1,0 +1,53 @@
+L.LevelButtons = L.Control.extend({
+	options:{
+		position: 'topright',
+		autoZIndex: true
+	},
+	onAdd: function(map){
+		this._map = map;
+		var plugin_container = L.DomUtil.create('div', 'levelbuttons-panel leaflet-bar');
+
+		var up_button = L.DomUtil.create('a', 'levelbuttons-panel-a', plugin_container);
+		up_button.innerHTML = '+';
+		up_button.href = '#';
+		L.DomEvent.addListener(up_button, 'click', this._onUpButton, this);
+		plugin_container.appendChild(up_button);
+
+		var down_button = L.DomUtil.create('a', 'levelbuttons-panel-a', plugin_container);
+		L.DomEvent.addListener(down_button, 'click', this._onDownButton, this);
+		down_button.innerHTML = '-';
+		down_button.href = '#';
+
+		plugin_container.appendChild(down_button);
+
+		return plugin_container;
+	},
+	onRemove: function(){},
+	_onUpButton: function(e){
+		upper_floor_index = this._tibia_map_obj.floor - 1;
+		if (upper_floor_index >= 0){
+			this._bringToFront(upper_floor_index);
+		}
+		L.DomEvent.stop(e);
+	},
+	_onDownButton: function(e){
+		lower_floor_index = this._tibia_map_obj.floor + 1;
+		if (lower_floor_index <= 15){
+			this._bringToFront(lower_floor_index);
+		}
+		L.DomEvent.stop(e);
+	},
+	setTibiaMap: function(tibia_map_obj){
+		this._tibia_map_obj = tibia_map_obj;
+	},
+	_bringToFront: function(layer_index){
+		// Simulate click on to choice option
+		// Its most bug free and efficient method of switching layers
+		// also it simplifies checking appropriate radio button in L.Controls.Layers widget
+		this.options.layers_widget._form[layer_index].click();
+	}
+});
+
+L.levelButtons = function(options) {
+	return new L.LevelButtons(options);
+}

--- a/src/_js/map.js
+++ b/src/_js/map.js
@@ -263,7 +263,7 @@
 			'Floor -7': this._createMapFloorLayer(14),
 			'Floor -8': this._createMapFloorLayer(15)
 		};
-		L.control.layers(baseMaps, {}).addTo(map);
+		var layers_widget = L.control.layers(baseMaps, {}).addTo(map);
 		var current = getUrlPosition();
 		_this.floor = current.floor;
 		map.setView(map.unproject([current.x, current.y], 0), current.zoom);
@@ -321,11 +321,13 @@
 				return '<b>X</b>: ' + coordY;
 			}
 		}).addTo(map);
+		L.LevelButtons.btns = L.levelButtons({layers_widget: layers_widget}).addTo(map);
 		_this._showHoverTile();
 	};
 
 	var map = new TibiaMap();
 	map.init();
+	L.LevelButtons.btns.setTibiaMap(map);
 
 	var fakeClick = function(target) {
 		var event = document.createEvent('MouseEvents');


### PR DESCRIPTION
Hello :)

I've made a plugin for leaflet which adds two buttons to map widget. First button is for changing map level to up second one is for going down.

This patch fixes issue "Use up and down icons for easier floor switching #1" from 20 Mar 2016.

Thanks :)
