### PR TITLE
Disable the broken touchscreen pinch-to-zoom gesture

### DIFF
--- a/src/_js/map.js
+++ b/src/_js/map.js
@@ -195,7 +195,8 @@
 			'scrollWheelZoom': !isEmbed,
 			'unloadInvisibleTiles': false,
 			'updateWhenIdle': true,
-			'zoomAnimationThreshold': 4
+			'zoomAnimationThreshold': 4,
+			'touchZoom': false
 		});
 		L.control.fullscreen({
 			'title': {


### PR DESCRIPTION
Disabled the pinch-to-zoom gesture, since it does not work and breaks the map, resulting in a frustrating experience for mobile users.